### PR TITLE
Fix get call issue with swagger client 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ class AnalyticsCoreAPI {
   getCalculatedMetrics ({ calculatedMetricFilter, expansion, limit = 10, locale, name, ownerId, page = 0, rsids, tagNames } = {}) {
     const sdkDetails = arguments[0]
     return new Promise((resolve, reject) => {
-      this.sdk.apis.calculatedmetrics.findCalculatedMetrics(arguments[0], this.__createRequest({}))
+      this.sdk.apis.calculatedmetrics.findCalculatedMetrics(arguments[0], this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -141,7 +141,7 @@ class AnalyticsCoreAPI {
     params.id = id
     const sdkDetails = params
     return new Promise((resolve, reject) => {
-      this.sdk.apis.calculatedmetrics.findOneCalculatedMetric(params, this.__createRequest({}))
+      this.sdk.apis.calculatedmetrics.findOneCalculatedMetric(params, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -164,7 +164,7 @@ class AnalyticsCoreAPI {
   getCollections ({ expansion, limit = 10, page = 0, rsidContains, rsids } = {}) {
     const sdkDetails = arguments[0]
     return new Promise((resolve, reject) => {
-      this.sdk.apis.collections.getCollections(arguments[0], this.__createRequest({}))
+      this.sdk.apis.collections.getCollections(arguments[0], this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -186,7 +186,7 @@ class AnalyticsCoreAPI {
     params.rsid = rsid
     const sdkDetails = params
     return new Promise((resolve, reject) => {
-      this.sdk.apis.collections.findOne(params, this.__createRequest({}))
+      this.sdk.apis.collections.findOne(params, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -209,7 +209,7 @@ class AnalyticsCoreAPI {
   getDateRanges ({ expansion, filterByIds, limit = 10, locale, page = 0 } = {}) {
     const sdkDetails = arguments[0]
     return new Promise((resolve, reject) => {
-      this.sdk.apis.dateranges.getDateRanges(arguments[0], this.__createRequest({}))
+      this.sdk.apis.dateranges.getDateRanges(arguments[0], this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -231,7 +231,7 @@ class AnalyticsCoreAPI {
     params.dateRangeId = dateRangeId
     const sdkDetails = params
     return new Promise((resolve, reject) => {
-      this.sdk.apis.dateranges.getDateRange(params, this.__createRequest({}))
+      this.sdk.apis.dateranges.getDateRange(params, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -256,7 +256,7 @@ class AnalyticsCoreAPI {
     params.rsid = rsid
     const sdkDetails = params
     return new Promise((resolve, reject) => {
-      this.sdk.apis.dimensions.dimensions_getDimensions(params, this.__createRequest({}))
+      this.sdk.apis.dimensions.dimensions_getDimensions(params, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -280,7 +280,7 @@ class AnalyticsCoreAPI {
     params.rsid = rsid
     const sdkDetails = params
     return new Promise((resolve, reject) => {
-      this.sdk.apis.dimensions.dimensions_getDimension(params, this.__createRequest({}))
+      this.sdk.apis.dimensions.dimensions_getDimension(params, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -305,7 +305,7 @@ class AnalyticsCoreAPI {
     params.rsid = rsid
     const sdkDetails = params
     return new Promise((resolve, reject) => {
-      this.sdk.apis.metrics.getMetrics(params, this.__createRequest({}))
+      this.sdk.apis.metrics.getMetrics(params, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -331,7 +331,7 @@ class AnalyticsCoreAPI {
     params.id = id
     const sdkDetails = params
     return new Promise((resolve, reject) => {
-      this.sdk.apis.metrics.getMetric(params, this.__createRequest({}))
+      this.sdk.apis.metrics.getMetric(params, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -375,7 +375,7 @@ class AnalyticsCoreAPI {
   getSegments ({ expansion, includeType, limit = 10, locale, name, page = 0, rsids, segmentFilter, tagNames } = {}) {
     const sdkDetails = arguments[0]
     return new Promise((resolve, reject) => {
-      this.sdk.apis.segments.segments_getSegments(arguments[0], this.__createRequest({}))
+      this.sdk.apis.segments.segments_getSegments(arguments[0], this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -414,7 +414,7 @@ class AnalyticsCoreAPI {
   getUsers ({ limit = 10, page = 0 } = {}) {
     const sdkDetails = arguments[0]
     return new Promise((resolve, reject) => {
-      this.sdk.apis.users.findAllUsers(arguments[0], this.__createRequest({}))
+      this.sdk.apis.users.findAllUsers(arguments[0], this.__createRequest(null))
         .then(response => {
           resolve(response)
         })
@@ -428,7 +428,7 @@ class AnalyticsCoreAPI {
   getCurrentUser () {
     const sdkDetails = {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.users.getCurrentUser({}, this.__createRequest({}))
+      this.sdk.apis.users.getCurrentUser({}, this.__createRequest(null))
         .then(response => {
           resolve(response)
         })


### PR DESCRIPTION
Fixes #52 
With new swagger client 3.10.12 get calls were failing for empty body. Fixed this.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tests and e2e tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
